### PR TITLE
fix cmds member's type must be string

### DIFF
--- a/lib/broker/message.rb
+++ b/lib/broker/message.rb
@@ -21,6 +21,22 @@ module Broker
       return [cmds, @data]
     end
 
+    def code=(v)
+      @code = v.to_s
+    end
+
+    def from=(v)
+      @from = v.to_s
+    end
+
+    def nav=(v)
+      @nav = v.to_s
+    end
+
+    def service=(v)
+      @service = v.to_s
+    end
+
     def to_s
       cmds, data = to_res
       return "cmds:#{cmds.join(',')} ; data: #{data}"


### PR DESCRIPTION
因为 go micro_borker 对 cmds 的解析全部定义为 string，若ruby client 提交的cmds 含有其它类型的信息，会导致反序列化失败。
